### PR TITLE
Make sure to remove old content controller before trigging didMoveToParent

### DIFF
--- a/ContainerController/Core/ContainerViewController.swift
+++ b/ContainerController/Core/ContainerViewController.swift
@@ -193,10 +193,10 @@ open class ContainerViewController: UIViewController {
 					log("Remove content controller: \(sourceContentController) from the stored embed controller as it shouldn't be reused." as AnyObject)
 					self.embedContentControllers.remove(at: index)
 			}
-			// Complete the adding of the new content controller
-			self.triggerDidMoveToParentViewControllerIfNeeded(targetContentController, isReused: isReused)
 			// Remove the old content controller as the animation is completed
 			sourceContentController.removeFromParent()
+			// Complete the adding of the new content controller
+			self.triggerDidMoveToParentViewControllerIfNeeded(targetContentController, isReused: isReused)
 			// Set the content controller as the current one
 			self.currentContentController = targetContentController
 			// Update the transition state flag


### PR DESCRIPTION
This change fixes the issue of when accessing the children of the container view controller in `didMove(toParent)`, only the new content controller is a child. Previously there was two children, the first the old and the second the new one.